### PR TITLE
Feature: add option to ignore partially supported features

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ npm install stylelint
 
 * `browsers`: optional. Accepts an array of browsers you want to support. For example `['> 1%', 'Last 2 versions']`. See [browserslist](https://github.com/ai/browserslist) for documentation.
 * `ignore`: optional. Accepts an array of features to ignore. For example: `['rem', 'css-table']`. Feature names can be found in the error messages.
+* `ignorePartialSupport`: optional. A boolean to turn off warnings for partially supported features.
 
 So for example, in a `.stylelintrc`:
 
@@ -49,7 +50,8 @@ So for example, in a `.stylelintrc`:
   "rules": {
     "plugin/no-unsupported-browser-features": [true, {
       "browsers": ["> 1%", "Last 2 versions"],
-      "ignore": ["rem"]
+      "ignore": ["rem"],
+      "ignorePartialSupport": true
     }]
   }
 }

--- a/lib/__snapshots__/index.test.js.snap
+++ b/lib/__snapshots__/index.test.js.snap
@@ -18,6 +18,33 @@ Object {
 }
 `;
 
+exports[`stylelint-no-unsupported-browser-features ignorePartialSupport option should not warn for flex when ignoring partially supported features 1`] = `
+Object {
+  "deprecations": Array [],
+  "invalidOptionWarnings": Array [],
+  "parseErrors": Array [],
+  "warnings": Array [],
+}
+`;
+
+exports[`stylelint-no-unsupported-browser-features ignorePartialSupport option should warn for flex without ignoring partially supported features 1`] = `
+Object {
+  "deprecations": Array [],
+  "errored": true,
+  "invalidOptionWarnings": Array [],
+  "parseErrors": Array [],
+  "warnings": Array [
+    Object {
+      "column": 7,
+      "line": 1,
+      "rule": "plugin/no-unsupported-browser-features",
+      "severity": "error",
+      "text": "Unexpected browser feature \\"flexbox\\" is only partially supported by IE 11 (plugin/no-unsupported-browser-features)",
+    },
+  ],
+}
+`;
+
 exports[`stylelint-no-unsupported-browser-features multiple browsers should allow display:table for IE 8 and IE 9 1`] = `
 Object {
   "deprecations": Array [],

--- a/lib/__snapshots__/index.test.js.snap
+++ b/lib/__snapshots__/index.test.js.snap
@@ -45,6 +45,24 @@ Object {
 }
 `;
 
+exports[`stylelint-no-unsupported-browser-features ignorePartialSupport option should warn when a feature is not supported by a browser and partly supported by another browser 1`] = `
+Object {
+  "deprecations": Array [],
+  "errored": true,
+  "invalidOptionWarnings": Array [],
+  "parseErrors": Array [],
+  "warnings": Array [
+    Object {
+      "column": 7,
+      "line": 1,
+      "rule": "plugin/no-unsupported-browser-features",
+      "severity": "error",
+      "text": "Unexpected browser feature \\"css-appearance\\" is not supported by IE 11 and only partially supported by Firefox 61 (plugin/no-unsupported-browser-features)",
+    },
+  ],
+}
+`;
+
 exports[`stylelint-no-unsupported-browser-features multiple browsers should allow display:table for IE 8 and IE 9 1`] = `
 Object {
   "deprecations": Array [],

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,16 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 
 const optionsSchema = {
   browsers: [_.isString],
-  ignore: [_.isString]
+  ignore: [_.isString],
+  ignorePartialSupport: [_.isBoolean]
 };
+
+/**
+ * Regular expressions
+ */
+
+const isPartiallySupportedRE = /only partially supported by/;
+const isNotSupportedRE = /not supported by/;
 
 /**
  * Utilities
@@ -65,6 +73,14 @@ function ruleFunction(on, options) {
 
     doiuse(doiuseOptions).postcss(root, doiuseResult);
     doiuseResult.warnings().forEach(doiuseWarning => {
+      if (
+        options.ignorePartialSupport &&
+        isPartiallySupportedRE.test(doiuseWarning.text) &&
+        isNotSupportedRE.test(doiuseWarning.text) === false
+      ) {
+        return;
+      }
+
       stylelint.utils.report({
         ruleName,
         result,

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -187,6 +187,52 @@ describe('stylelint-no-unsupported-browser-features', () => {
     });
   });
 
+  describe('ignorePartialSupport option', () => {
+    it('should warn for flex without ignoring partially supported features', done => {
+      const code = 'div { display: flex; }';
+      const rules = {
+        'plugin/no-unsupported-browser-features': [
+          true,
+          {
+            browsers: ['IE 11']
+          }
+        ]
+      };
+      const options = getOptions(code, rules);
+
+      return stylelint
+        .lint(options)
+        .then(result => {
+          expect(result.errored).toBe(true);
+          expect(parseResult(result.output)).toMatchSnapshot();
+          return done();
+        })
+        .catch(error => done(error));
+    });
+    it('should not warn for flex when ignoring partially supported features', done => {
+      const code = 'div { display: flex; }';
+      const rules = {
+        'plugin/no-unsupported-browser-features': [
+          true,
+          {
+            browsers: ['IE 11'],
+            ignorePartialSupport: true
+          }
+        ]
+      };
+      const options = getOptions(code, rules);
+
+      return stylelint
+        .lint(options)
+        .then(result => {
+          expect(result.errored).toBe(false);
+          expect(parseResult(result.output)).toMatchSnapshot();
+          return done();
+        })
+        .catch(error => done(error));
+    });
+  });
+
   describe('validate options', () => {
     it('should validate the browsers option', done => {
       const code = '';

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -231,6 +231,28 @@ describe('stylelint-no-unsupported-browser-features', () => {
         })
         .catch(error => done(error));
     });
+    it('should warn when a feature is not supported by a browser and partly supported by another browser', done => {
+      const code = 'div { appearance: none; }';
+      const rules = {
+        'plugin/no-unsupported-browser-features': [
+          true,
+          {
+            browsers: ['IE 11', 'Firefox 61'],
+            ignorePartialSupport: true
+          }
+        ]
+      };
+      const options = getOptions(code, rules);
+
+      return stylelint
+        .lint(options)
+        .then(result => {
+          expect(result.errored).toBe(true);
+          expect(parseResult(result.output)).toMatchSnapshot();
+          return done();
+        })
+        .catch(error => done(error));
+    });
   });
 
   describe('validate options', () => {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-import": "^2.13.0",
     "husky": "^0.14.3",
     "jest": "^23.4.1",
+    "jest-cli": "^23.6.0",
     "key-del": "^1.3.0",
     "lint-staged": "^7.0.0",
     "prettier": "^1.13.2",


### PR DESCRIPTION
### Motivation

Currently the plugin always shows warnings for features with no support or only partial support. Most of the partially supported features actually work, but have some bugs or do not fully support all the features in the spec for that feature.

In my project I'm only interested in seeing which CSS properties _do not work at all_ for the browsers that I have defined in `browserslist`. 

By only warning for non-supported features, the stylelint output is nicer to read as it gets rid of a lot of warnings that are not helpful. I could of course use the `ignore` option to create a list of ignored properties, but then I need to keep updating it and it does not really do the same thing anyway.

### Implementation

I think that the best way to support this feature is to add a new option that the user can use to opt-in to ignoring partially supported properties.

@ismay 