### PR TITLE
Move tooling configuration out of package.json

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: 'jest-preset-stylelint',
+};

--- a/package.json
+++ b/package.json
@@ -54,13 +54,5 @@
     "lint-staged": "^10.4.2",
     "prettier": "^2.1.2",
     "stylelint": "^13.7.2"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "jest": {
-    "preset": "jest-preset-stylelint"
   }
 }


### PR DESCRIPTION
Since `package.json` is already rather cluttered.