### PR TITLE
Test all peer dependency major versions on ci

### DIFF
--- a/.tav.yml
+++ b/.tav.yml
@@ -1,0 +1,7 @@
+stylelint:
+  - versions: "~13.0.0"
+    commands: npm test
+  - versions: "~12.0.1"
+    commands: npm test
+  - versions: "~11.1.1"
+    commands: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - 12
   - 10
 script:
-  - npm run test
+  - npm run test:tav
 jobs:
   include:
     - stage: lint

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "codecov": "codecov",
     "test": "cross-env BROWSERSLIST_DISABLE_CACHE=true BROWSERSLIST='IE 8' jest",
+    "test:tav": "tav",
     "test:coverage": "cross-env BROWSERSLIST_DISABLE_CACHE=true BROWSERSLIST='IE 8' jest --coverage",
-    "test:watch": "cross-env BROWSERSLIST_DISABLE_CACHE=true BROWSERSLIST='IE 8' jest --watch",
     "lint:prettier": "prettier --list-different '**/*.js'",
     "lint:js": "eslint '**/*.js'"
   },
@@ -53,6 +53,7 @@
     "jest-preset-stylelint": "^3.0.0",
     "lint-staged": "^10.4.2",
     "prettier": "^2.1.2",
-    "stylelint": "^13.7.2"
+    "stylelint": "^13.7.2",
+    "test-all-versions": "^5.0.1"
   }
 }


### PR DESCRIPTION
Closes #117 

Using https://github.com/watson/test-all-versions. I don't want to test with every possible version, that seems like a bit much. So this just tests with a single version from each major version that matches the peerDependency range for stylelint.