### PR TITLE
Increment postcss version to avoid warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "doiuse": "^4.4.1",
     "lodash": "^4.17.15",
-    "postcss": "^8.1.4"
+    "postcss": "^8.3.6"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",


### PR DESCRIPTION
I use WebStorm v2021.1.1 and we use `stylelint-no-unsupported-browser-features` in our project. I am constantly getting a warning from the IDE as in the attached screenshot.

As it says, the problem is in `stylelint-no-unsupported-browser-features/node_modules/postcss/package.json` in the `exports` field:

```
"exports": {
    ".": {
      "require": "./lib/postcss.js",
      "import": "./lib/postcss.mjs",
      "types": "./lib/postcss.d.ts"
    },
    "./": "./" // <- HERE
  },
``` 
However, the newer versions of `postcss` use different `exports` field and the annoying warning disappears)))

<img width="1010" alt="Screenshot 2021-09-10 at 13 56 04" src="https://user-images.githubusercontent.com/28143822/132843486-b9192fd1-0270-441f-9e5b-7ebcecfe4c3b.png">
