### PR TITLE
fix: Fix detecting a mix of supported/unsupported rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,15 +75,17 @@ function ruleFunction(on, options) {
     const doiuseOptions = _.pick(options, Object.keys(optionsSchema));
     const doiuseResult = new Result();
 
-    let usageInfo;
+    const usedFeatures = {};
 
     doiuseOptions.onFeatureUsage = (info) => {
-      usageInfo = info;
+      // Use the node as key to store feature information
+      usedFeatures[info.usage] = info.featureData;
     };
 
     doiuse(doiuseOptions).postcss(root, doiuseResult);
     doiuseResult.warnings().forEach((doiuseWarning) => {
-      if (ignorePartialSupport && usageInfo.featureData.partial && !usageInfo.featureData.missing) {
+      const featureData = usedFeatures[doiuseWarning.node];
+      if (featureData && ignorePartialSupport && featureData.partial && !featureData.missing) {
         return;
       }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -236,3 +236,26 @@ testRule({
     },
   ],
 });
+
+// IE 11 mix of not supported and partially supported
+testRule({
+  plugins: ['.'],
+  ruleName,
+  config: [
+    true,
+    {
+      browsers: ['IE 11'],
+      ignorePartialSupport: true,
+    },
+  ],
+
+  reject: [
+    {
+      code: 'div { display: flex;\nposition: sticky; }',
+      description: 'handle unsupported and partially supported separately',
+      message: `Unexpected browser feature "css-sticky" is not supported by IE 11 (plugin/no-unsupported-browser-features)`,
+      line: 2,
+      column: 1,
+    },
+  ],
+});


### PR DESCRIPTION
Fix for https://github.com/ismay/stylelint-no-unsupported-browser-features/issues/230.

When there is a mix of supported, unsupported, and partially supported features in a document, the link between `doiuse` features and `postcss` warnings can get mixed up. That's because the `onFeatureUsage` callback is called separately from the `doiuseResult.warnings()` loop.

To fix this problem, `doiuse` features are stored in an object first, using the node as the key. We can then access that information later by referencing the same node in the `doiuse` warning.