### PR TITLE
fix: resolve browsers option by default to improve performance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 import stylelint from 'stylelint';
+import browserslist from 'browserslist';
 import doiuse from 'doiuse';
 import { Result } from 'postcss';
 
@@ -28,6 +29,8 @@ const optionsSchema = {
   ignore: [isString],
   ignorePartialSupport: isBoolean,
 };
+
+const defaultBrowsers = browserslist();
 
 /**
  * Utilities
@@ -86,6 +89,10 @@ function ruleFunction(on, options) {
       Object.keys(optionsSchema).forEach((optionsKey) => {
         doiuseOptions[optionsKey] = options[optionsKey];
       });
+    }
+
+    if (!doiuseOptions.browsers) {
+      doiuseOptions.browsers = defaultBrowsers;
     }
 
     doiuseOptions.onFeatureUsage = (info) => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "stylelint": "^16.0.2"
   },
   "dependencies": {
+    "browserslist": "^4.26.3",
     "doiuse": "^6.0.5",
     "postcss": "^8.4.32"
   },


### PR DESCRIPTION
I was benchmarking performance of Stylelint plugins in my project and discovered that `stylelint-no-unsupported-browser-features` plugin accounts for approximately 91% of the total execution time.

After further investigation, I identified that majority of the time is spent resolving the `browserslist` configuration within `doiuse` dependency.

This pull request introduces a default `browserslist` configuration resolution, allowing `doiuse` to skip that step during each file validation, improving overall performance significantly.

On my project with approximately 600 style files, plugin execution time decreased from 26724 ms to 137 ms, resulting in an approximate 200x performance improvement.